### PR TITLE
增加 日志输出到exceptionless

### DIFF
--- a/src/Admin/WebHost/appsettings.Development.json
+++ b/src/Admin/WebHost/appsettings.Development.json
@@ -31,6 +31,15 @@
           //使用缓冲，提高写入效率
           "buffered": false
         }
+      },
+      //输出到Exceptionless  
+      //v5.0提供docker images
+      {
+        "Name": "Exceptionless",
+        "Args": {
+          "apiKey": "",
+          "serverUrl": ""
+        }
       }
     ]
   },

--- a/src/Framework/Logging/Logging.Serilog.GenericHost/Logging.Serilog.GenericHost.csproj
+++ b/src/Framework/Logging/Logging.Serilog.GenericHost/Logging.Serilog.GenericHost.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Exceptionless" Version="3.1.3" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
   </ItemGroup>
 

--- a/src/Framework/Logging/Logging.Serilog/Logging.Serilog.csproj
+++ b/src/Framework/Logging/Logging.Serilog/Logging.Serilog.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Exceptionless" Version="3.1.3" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
   </ItemGroup>
   


### PR DESCRIPTION
当使用nm进行分布式部署的，可以选择Exceptionless，并且Eceptionless 5.0后提供docker和kubernetes版，私有化部署非常方便