### PR TITLE
Switch to MySqlConnector

### DIFF
--- a/src/Framework/Data/Db/Data.MySql/Data.MySql.csproj
+++ b/src/Framework/Data/Db/Data.MySql/Data.MySql.csproj
@@ -14,7 +14,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="MySql.Data" Version="8.0.21" />
+    <PackageReference Include="MySqlConnector" Version="1.3.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Framework/Data/Db/Data.MySql/MySqlAdapter.cs
+++ b/src/Framework/Data/Db/Data.MySql/MySqlAdapter.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Extensions.Logging;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using NetModular.Lib.Data.Abstractions;
 using NetModular.Lib.Data.Abstractions.Entities;
 using NetModular.Lib.Data.Abstractions.Enums;
@@ -49,20 +49,6 @@ namespace NetModular.Lib.Data.MySql
 
             Options.Version = DbOptions.Version;
 
-            #region ==字符编码==
-
-            var characterSet = "utf8";
-            if (Options.MySqlCharacterSet.NotNull())
-            {
-                characterSet = Options.MySqlCharacterSet;
-            }
-            else if (DbOptions.MySqlCharacterSet.NotNull())
-            {
-                characterSet = DbOptions.MySqlCharacterSet;
-            }
-
-            #endregion
-
             #region ==SslMode==
 
             var sslModeStr = "None";
@@ -87,7 +73,6 @@ namespace NetModular.Lib.Data.MySql
                 UserID = DbOptions.UserId,
                 Password = DbOptions.Password,
                 AllowUserVariables = true,
-                CharacterSet = characterSet,
                 SslMode = sslModel,
                 AllowPublicKeyRetrieval = true,
                 MinimumPoolSize = DbOptions.MinPoolSize < 1 ? 0u : DbOptions.MinPoolSize.ToByte(),

--- a/src/Framework/Data/Db/Data.MySql/MySqlDbContextOptions.cs
+++ b/src/Framework/Data/Db/Data.MySql/MySqlDbContextOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Data;
 using Microsoft.Extensions.Logging;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using NetModular.Lib.Auth.Abstractions;
 using NetModular.Lib.Data.Abstractions.Options;
 using NetModular.Lib.Data.Core;


### PR DESCRIPTION
Fixes #102.

Also removed the `CharacterSet` connection string option because MySqlConnector always uses `utf8mb4`.